### PR TITLE
Updated ts-jest to fix an error preventing me from running the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "ts-auto-mock": "^2.6.5",
-    "ts-jest": "^26.4.2",
+    "ts-jest": "^27.0.1",
     "ts-node": "^9.0.0",
     "ttypescript": "^1.5.12",
     "typescript": "^4.0.3",


### PR DESCRIPTION
I forked the code and attempted to run `npm run test` and had the following error.

"TypeError: Jest: a transform must export somthing." 

I found a solution here (https://github.com/kulshekhar/ts-jest/issues/2612) to fix the issue by updating ts-test to ^27.0.1