### PR TITLE
Feature/get quotes response

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "ts-auto-mock": "^2.6.5",
-    "ts-jest": "^26.4.2",
+    "ts-jest": "^27.0.1",
     "ts-node": "^9.0.0",
     "ttypescript": "^1.5.12",
     "typescript": "^4.0.3",

--- a/src/clients/quotes-client.ts
+++ b/src/clients/quotes-client.ts
@@ -49,8 +49,19 @@ export default class QuotesClient {
 
     const url = `${getQuotesUrl()}${queryString}`;
 
-    return this._client._makeRequest(
-      async (authConfig) => await Axios.get<Quote[]>(url, authConfig)
-    );
+    return this._client
+      ._makeRequest(
+        async (authConfig) => await Axios.get<Quote[]>(url, authConfig)
+      )
+      .then((result: AxiosResponse<Quote[]>) => {
+        const stocks = [] as Quote[];
+        Object.keys(result.data).map((symbol: any) => {
+          stocks.push(result.data[symbol]);
+        });
+
+        return {
+          data: stocks,
+        } as AxiosResponse<Quote[]>;
+      });
   };
 }

--- a/src/clients/quotes-client.ts
+++ b/src/clients/quotes-client.ts
@@ -47,7 +47,7 @@ export default class QuotesClient {
   ): Promise<AxiosResponse<Quote[]>> => {
     const queryString = qs.stringify({ symbol, apiKey }, queryStringOptions);
 
-    const url = `${getQuotesUrl}${queryString}`;
+    const url = `${getQuotesUrl()}${queryString}`;
 
     return this._client._makeRequest(
       async (authConfig) => await Axios.get<Quote[]>(url, authConfig)

--- a/tests/clients/quotes-client.test.ts
+++ b/tests/clients/quotes-client.test.ts
@@ -18,7 +18,15 @@ describe('Quotes client tests', () => {
   it('should get quote', async () => {
     const expectedResult = createMock<Quote>();
 
-    mockedAxios.get.mockResolvedValueOnce({ data: expectedResult });
+    mockedAxios.get.mockImplementationOnce((url: string) => {
+      if (
+        url === 'https://api.tdameritrade.com/v1/marketdata/My quote/quotes'
+      ) {
+        return Promise.resolve({ data: expectedResult });
+      } else {
+        return Promise.resolve({ data: `unknown url: ${url}` });
+      }
+    });
 
     const { data } = await client.quotes.getQuote('My quote');
 
@@ -28,10 +36,19 @@ describe('Quotes client tests', () => {
   it('should get quotes', async () => {
     const expectedResult = createMock<Quote[]>();
 
-    mockedAxios.get.mockResolvedValueOnce({ data: expectedResult });
+    mockedAxios.get.mockImplementationOnce((url: string) => {
+      if (
+        url ===
+        'https://api.tdameritrade.com/v1/marketdata/quotes?symbol=my%20quote'
+      ) {
+        return Promise.resolve({ data: expectedResult });
+      } else {
+        return Promise.resolve({ data: `unknown url: ${url}` });
+      }
+    });
 
     const { data } = await client.quotes.getQuotes(['my quote']);
 
-    expect(data).toBe(expectedResult);
+    expect(data).toEqual([]);
   });
 });

--- a/tests/clients/quotes-client.test.ts
+++ b/tests/clients/quotes-client.test.ts
@@ -34,14 +34,30 @@ describe('Quotes client tests', () => {
   });
 
   it('should get quotes', async () => {
-    const expectedResult = createMock<Quote[]>();
+    const expectedResult = createMock<Quote[]>([
+      {
+        symbol: 'AMC',
+      } as any,
+      {
+        symbol: 'GME',
+      } as any,
+    ]);
 
     mockedAxios.get.mockImplementationOnce((url: string) => {
       if (
         url ===
         'https://api.tdameritrade.com/v1/marketdata/quotes?symbol=my%20quote'
       ) {
-        return Promise.resolve({ data: expectedResult });
+        return Promise.resolve({ data:  {
+
+        AMC: {
+          symbol: 'AMC',
+        },
+        GME: {
+          symbol: 'GME',
+        }
+        }
+        });
       } else {
         return Promise.resolve({ data: `unknown url: ${url}` });
       }
@@ -49,6 +65,6 @@ describe('Quotes client tests', () => {
 
     const { data } = await client.quotes.getQuotes(['my quote']);
 
-    expect(data).toEqual([]);
+    expect(data).toEqual(expectedResult);
   });
 });


### PR DESCRIPTION
Once I was able to fix "getQuotes" to call the getQuotesUrl function, I realized that the response was not correct as AxiosResponse<Quote[]>.

The reason is the Td ameritrade document is not correct. https://developer.tdameritrade.com/quotes/apis/get/marketdata/quotes

Though the documentation shows that is returns a collection of type Quote, it actually returns an object of objects with the hashed key as the symbol.

{
  AMC: {
    assetType: 'EQUITY',
    assetMainType: 'EQUITY',
    cusip: '00165C104',
    symbol: 'AMC',
    description: 'AMC Entertainment Holdings, Inc. Class A Common Stock',
    bidPrice: 37.31,
    bidSize: 200,
    bidId: 'P',
    askPrice: 37.32,
    askSize: 200,
    askId: 'T',
    lastPrice: 37.31,
    lastSize: 100,
    lastId: 'P',
    openPrice: 36.86,
    highPrice: 38.1,
    lowPrice: 36.19,
    bidTick: ' ',
    closePrice: 36.77,
    netChange: 0.54,
    totalVolume: 28732253,
    quoteTimeInLong: 1633455258346,
    tradeTimeInLong: 1633455258345,
    mark: 37.31,
    exchange: 'n',
    exchangeName: 'NYSE',
    marginable: true,
    shortable: true,
    volatility: 0.02,
    digits: 2,
    '52WkHigh': 72.62,
    '52WkLow': 1.91,
    nAV: 0,
    peRatio: 0,
    divAmount: 0,
    divYield: 0,
    divDate: '',
    securityStatus: 'Normal',
    regularMarketLastPrice: 37.31,
    regularMarketLastSize: 1,
    regularMarketNetChange: 0.54,
    regularMarketTradeTimeInLong: 1633455258345,
    netPercentChangeInDouble: 1.4686,
    markChangeInDouble: 0.54,
    markPercentChangeInDouble: 1.4686,
    regularMarketPercentChangeInDouble: 1.4686,
    delayed: false,
    realtimeEntitled: true
  },
  GME: {
    assetType: 'EQUITY',
    assetMainType: 'EQUITY',
    cusip: '36467W109',
    symbol: 'GME',
    description: 'GameStop Corporation Common Stock',
    bidPrice: 170.14,
    bidSize: 100,
    bidId: 'H',
    askPrice: 170.45,
    askSize: 200,
    askId: 'T',
    lastPrice: 170.15,
    lastSize: 100,
    lastId: 'D',
    openPrice: 171.19,
    highPrice: 173,
    lowPrice: 166.7,
    bidTick: ' ',
    closePrice: 171.36,
    netChange: -1.21,
    totalVolume: 840827,
    quoteTimeInLong: 1633455254939,
    tradeTimeInLong: 1633455246355,
    mark: 170.15,
    exchange: 'n',
    exchangeName: 'NYSE',
    marginable: true,
    shortable: true,
    volatility: 0.106,
    digits: 2,
    '52WkHigh': 483,
    '52WkLow': 9.1,
    nAV: 0,
    peRatio: 0,
    divAmount: 0,
    divYield: 0,
    divDate: '',
    securityStatus: 'Normal',
    regularMarketLastPrice: 170.15,
    regularMarketLastSize: 1,
    regularMarketNetChange: -1.21,
    regularMarketTradeTimeInLong: 1633455246355,
    netPercentChangeInDouble: -0.7061,
    markChangeInDouble: -1.21,
    markPercentChangeInDouble: -0.7061,
    regularMarketPercentChangeInDouble: -0.7061,
    delayed: false,
    realtimeEntitled: true
  }
}

I am not an expert on Axios and I fixed the response to be a collection of type Quote.

I separated my pull requests to allow you to decide how to best handle the "GetQuotesUrl" function bug and this response.

There will be merge conflicts depending on which PR is merged first. 