### PR TITLE
Feature/transaction history update

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "ts-auto-mock": "^2.6.5",
-    "ts-jest": "^26.4.2",
+    "ts-jest": "^27.0.1",
     "ts-node": "^9.0.0",
     "ttypescript": "^1.5.12",
     "typescript": "^4.0.3",

--- a/src/clients/transaction-history-client.ts
+++ b/src/clients/transaction-history-client.ts
@@ -43,8 +43,8 @@ export default class TransactionHistoryClient {
     accountId: numberOrString,
     type: TransactionType,
     symbol: string,
-    startDate: Date,
-    endDate: Date
+    startDate: string,
+    endDate: string
   ): Promise<AxiosResponse<Transaction[]>> => {
     const queryString = qs.stringify(
       { type, symbol, startDate, endDate },

--- a/tests/clients/transaction-history-client.test.ts
+++ b/tests/clients/transaction-history-client.test.ts
@@ -28,19 +28,62 @@ describe('Transaction history client tests', () => {
     expect(data).toBe(expectedResult);
   });
 
-  it('should get transaction', async () => {
-    const expectedResult = createMock<Transaction[]>();
+  it('should get transactions', async () => {
+    const expectedResult = createMock<Transaction[]>([
+      {
+        type: 'TRADE',
+        subAccount: '4',
+        settlementDate: '2021-10-07',
+        description: 'CLOSE SHORT POSITION',
+        fees: {
+          rFee: 0,
+        },
+        transactionItem: {
+          amount: 100,
+          price: 74.8499,
+          cost: -7484.99,
+          instruction: 'BUY',
+        },
+      },
+    ]);
 
-    mockedAxios.get.mockResolvedValueOnce({ data: expectedResult });
+    mockedAxios.get.mockImplementationOnce((url: string) => {
+      if (
+        url ===
+        'https://api.tdameritrade.com/v1/accounts/accountId/transactions?type=ALL&symbol=symbol&startDate=2021-10-05&endDate=2021-10-06'
+      ) {
+        return Promise.resolve({
+          data: [
+            {
+              type: 'TRADE',
+              subAccount: '4',
+              settlementDate: '2021-10-07',
+              description: 'CLOSE SHORT POSITION',
+              fees: {
+                rFee: 0,
+              },
+              transactionItem: {
+                amount: 100,
+                price: 74.8499,
+                cost: -7484.99,
+                instruction: 'BUY',
+              },
+            },
+          ],
+        });
+      } else {
+        return Promise.resolve({ data: `unknown url: ${url}` });
+      }
+    });
 
     const { data } = await client.transactionHistory.getTransactions(
       'accountId',
       'ALL',
       'symbol',
-      new Date(),
-      new Date()
+      '2021-10-05',
+      '2021-10-06'
     );
 
-    expect(data).toBe(expectedResult);
+    expect(data).toEqual(expectedResult);
   });
 });


### PR DESCRIPTION
Fixed the transaction history from dates to strings per the Td Ameritrade documentation

https://developer.tdameritrade.com/transaction-history/apis/get/accounts/%7BaccountId%7D/transactions-0

Only transactions after the Start Date will be returned.
Note: The maximum date range is one year. Valid ISO-8601 formats are :
yyyy-MM-dd.