### PR TITLE
Updates to the getQuote in the quotes-client

### DIFF
--- a/src/clients/quotes-client.ts
+++ b/src/clients/quotes-client.ts
@@ -37,7 +37,19 @@ export default class QuotesClient {
     const url = `${getQuoteUrl(symbol)}${queryString}`;
 
     return this._client._makeRequest(
-      async (authConfig) => await Axios.get<Quote>(url, authConfig)
+      async (authConfig) =>
+        await Axios.get<Quote>(url, authConfig).then(
+          (result: AxiosResponse<any>) => {
+            let quote = {} as Quote;
+            Object.keys(result.data).map((symbol: string) => {
+              quote = result.data[symbol] as Quote;
+            });
+
+            return {
+              data: quote,
+            } as AxiosResponse<Quote>;
+          }
+        )
     );
   };
 

--- a/tests/clients/quotes-client.test.ts
+++ b/tests/clients/quotes-client.test.ts
@@ -16,21 +16,35 @@ describe('Quotes client tests', () => {
   });
 
   it('should get quote', async () => {
-    const expectedResult = createMock<Quote>();
+    const expectedResult = createMock<Quote>(
+      Object({
+        symbol: 'AMC',
+      })
+    );
 
     mockedAxios.get.mockImplementationOnce((url: string) => {
-      if (
-        url === 'https://api.tdameritrade.com/v1/marketdata/My quote/quotes'
-      ) {
-        return Promise.resolve({ data: expectedResult });
+      if (url === 'https://api.tdameritrade.com/v1/marketdata/AMC/quotes') {
+        return Promise.resolve({
+          data: Object({
+            AMC: Object({
+              symbol: 'AMC',
+              netPercentChangeInDouble: 0,
+              markChangeInDouble: 0,
+              markPercentChangeInDouble: 0,
+              regularMarketPercentChangeInDouble: 0,
+              delayed: false,
+              realtimeEntitled: false,
+            }),
+          }),
+        });
       } else {
         return Promise.resolve({ data: `unknown url: ${url}` });
       }
     });
 
-    const { data } = await client.quotes.getQuote('My quote');
+    const { data } = await client.quotes.getQuote('AMC');
 
-    expect(data).toBe(expectedResult);
+    expect(data).toEqual(expectedResult);
   });
 
   it('should get quotes', async () => {
@@ -48,15 +62,15 @@ describe('Quotes client tests', () => {
         url ===
         'https://api.tdameritrade.com/v1/marketdata/quotes?symbol=my%20quote'
       ) {
-        return Promise.resolve({ data:  {
-
-        AMC: {
-          symbol: 'AMC',
-        },
-        GME: {
-          symbol: 'GME',
-        }
-        }
+        return Promise.resolve({
+          data: {
+            AMC: {
+              symbol: 'AMC',
+            },
+            GME: {
+              symbol: 'GME',
+            },
+          },
         });
       } else {
         return Promise.resolve({ data: `unknown url: ${url}` });


### PR DESCRIPTION
The actual response for TD Ameritrade is an object with the key as the quote symbol and the value is the actual Quote.

See below

{
  AMC: {
    assetType: 'EQUITY',
    assetMainType: 'EQUITY',
    cusip: '00165C104',
    symbol: 'AMC',
    description: 'AMC Entertainment Holdings, Inc. Class A Common Stock',
    bidPrice: 35.25,
    bidSize: 500,
    bidId: 'K',
    askPrice: 35.27,
    askSize: 1200,
    askId: 'P',
    lastPrice: 35.25,
    lastSize: 0,
    lastId: 'D',
    openPrice: 35.34,
    highPrice: 36.6298,
    lowPrice: 34.53,
    bidTick: ' ',
    closePrice: 35.23,
    netChange: 0.02,
    totalVolume: 32569894,
    quoteTimeInLong: 1635538471069,
    tradeTimeInLong: 1635538471076,
    mark: 35.27,
    exchange: 'n',
    exchangeName: 'NYSE',
    marginable: true,
    shortable: true,
    volatility: 0.0228,
    digits: 2,
    '52WkHigh': 72.62,
    '52WkLow': 1.91,
    nAV: 0,
    peRatio: 0,
    divAmount: 0,
    divYield: 0,
    divDate: '',
    securityStatus: 'Normal',
    regularMarketLastPrice: 35.37,
    regularMarketLastSize: 3197,
    regularMarketNetChange: 0.14,
    regularMarketTradeTimeInLong: 1635538200004,
    netPercentChangeInDouble: 0.0568,
    markChangeInDouble: 0.04,
    markPercentChangeInDouble: 0.1135,
    regularMarketPercentChangeInDouble: 0.3974,
    delayed: false,
    realtimeEntitled: true
  }
}